### PR TITLE
Add wrapper for rendering in custom dialog

### DIFF
--- a/src/dialogs/custom.js
+++ b/src/dialogs/custom.js
@@ -28,6 +28,7 @@
  * @licence Simplified BSD License
  */
 
+import {app, h} from 'hyperapp';
 import Dialog from '../dialog';
 
 /**
@@ -43,6 +44,24 @@ export default class CustomDialog extends Dialog {
 
   render(render) {
     return super.render({}, ($content, win) => render($content, win, this));
+  }
+
+  renderCustom(render, styles = {}) {
+    return this.render(($content, dialogWindow, dialog) => {
+      app({}, {}, () => {
+        return this.createView([
+          h('div', {
+            style: {
+              'flex-grow': 1,
+              'flex-shrink': 1,
+              position: 'relative',
+              ...styles
+            },
+            oncreate: $el => render($el, dialogWindow, dialog)
+          })
+        ]);
+      }, $content);
+    });
   }
 
   getValue() {


### PR DESCRIPTION
This allows to create custom dialogs without relying on Hyperapp to
construct the intial UI with buttons in the custom dialog.

---

Right now to create a custom dialog with buttons, following https://manual.os-js.org/tutorial/dialog the `.render()` call needs to be set up with some scaffolding. I added `.renderCustom()` that has the same signature, but gives you the buttons out of the box.