### PR TITLE
Disable ok button when choosing a directory in save dialog

### DIFF
--- a/src/dialogs/file.js
+++ b/src/dialogs/file.js
@@ -196,6 +196,7 @@ export default class FileDialog extends Dialog {
             if (data.isDirectory) {
               a.setFilename(null);
               a.setPath(data);
+              a.setButtonState({ok: false});
             } else {
               this.value = data.isFile ? data : null;
               this.emitCallback(this.getPositiveButton(), ev, true);


### PR DESCRIPTION
Since the file name input field gets cleared, the ok button should also become disabled until the user types in the file name.