### PR TITLE
fix(file): revert ok button behaviour for open dialogs

### DIFF
--- a/src/dialogs/file.js
+++ b/src/dialogs/file.js
@@ -127,7 +127,9 @@ export default class FileDialog extends Dialog {
           }]
         }),
         buttons: {
-          ok: !!this.args.filename
+          ok: this.args.type === 'open' && this.args.filetype === 'directory'
+            ? true
+            : !!this.args.filename
         }
       }, {
         _readdir: ({path, files}) => (state, actions) => {


### PR DESCRIPTION
I made a mistake in #21 and I now realize what the previous code was intended for. In our testing, the `open-file` dialog now has its OK button disabled by default when selecting directories, even when an initial `path` is given.

I believe the correct behaviour for the OK button should be:

| Dialog type (`this.args.type`) | File Type (`this.args.filetype`) | is File Name Provided (`!!this.args.filename`) | is OK button enabled as a result |
| - | - | - | - |
| open | file | no | no |
| open | file | yes | yes |
| open | directory | no | yes (used to be no)*** |
| open | directory | yes | yes*** |
| open | file | no | no |
| open | file | yes | yes |
| open | directory | no | no |
| open | directory | yes | yes |

*** only `path` will get used for the final value since there is no input box for directory name

We have tested this extensively and hope that it works as intended now. Apologies!

Also, pleas note that the expression can be further abbreviated to:
```js
buttons: {
  ok: (this.args.type === 'open' && this.args.filetype === 'directory') || !!this.args.filename
}
````
